### PR TITLE
fix(aerospace): set config-version 2, modernize finder rule

### DIFF
--- a/aerospace/aerospace.toml
+++ b/aerospace/aerospace.toml
@@ -1,3 +1,6 @@
+# Config version (opt into latest behavior; silences reload-config deprecation warning)
+config-version = 2
+
 # -- Start AeroSpace & Sketchybar at login
 start-at-login = true
 after-startup-command = ['exec-and-forget sketchybar']
@@ -23,7 +26,7 @@ automatically-unhide-macos-hidden-apps = false
 
 # Floating finder
 [[on-window-detected]]
-if.app-name-regex-substring = 'finder'
+if = 'test %{app-bundle-id} = com.apple.finder'
 run = 'layout floating'
 
 # Gaps between windows (inner-*) and between monitor edges (outer-*).


### PR DESCRIPTION
## What

Reviewed `aerospace/aerospace.toml` against upstream AeroSpace 0.21 (installed: app 0.21.1-Beta, CLI 0.21.3-Beta).

Two changes:

1. **Add `config-version = 2`.** Omitting the key defaults to `config-version = 1`. Per the [guide](https://nikitabobko.github.io/AeroSpace/guide#config-version), a version below the highest emits a deprecation warning to stderr on every `reload-config` — which this config triggers via the service-mode `esc` binding. Version 2 is the current recommended value.

2. **Modernize the Finder float rule.** Replaced the soft-deprecated `if.app-name-regex-substring = 'finder'` matcher with `if = 'test %{app-bundle-id} = com.apple.finder'`. Exact bundle-id match, avoids accidental substring hits, and uses the non-deprecated syntax.

## Why

Silence the reload-config warning and drop deprecated config syntax before it bites on a future upgrade.

## Reviewer notes

- `config-version = 2` changes the `persistent-workspaces` fallback from inferred-from-bindings to an empty array. This config doesn't set `persistent-workspaces` and only uses workspaces 1-4, so empty workspaces get destroyed (standard AeroSpace behavior) — no visible change in practice.
- All other keys, commands, flags, and gaps syntax verified current for 0.21; nothing removed or otherwise deprecated.
- TOML validated with `tomllib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)